### PR TITLE
feat: enable internal and external links in CKEditor5

### DIFF
--- a/assets/admin/components/CKEditor5Configurable.js
+++ b/assets/admin/components/CKEditor5Configurable.js
@@ -18,6 +18,8 @@ import TablePlugin from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbarPlugin from '@ckeditor/ckeditor5-table/src/tabletoolbar';
 import FontPlugin from '@ckeditor/ckeditor5-font/src/font';
 import {translate} from 'sulu-admin-bundle/utils/Translator';
+import ExternalLinkPlugin from "sulu-admin-bundle/containers/CKEditor5/plugins/ExternalLinkPlugin";
+import InternalLinkPlugin from "sulu-admin-bundle/containers/CKEditor5/plugins/InternalLinkPlugin";
 import configRegistry from 'sulu-admin-bundle/containers/CKEditor5/registries/configRegistry';
 import pluginRegistry from 'sulu-admin-bundle/containers/CKEditor5/registries/pluginRegistry';
 import type {IObservableValue} from 'mobx/lib/mobx';
@@ -86,6 +88,8 @@ export default class CKEditor5Configurable extends React.Component<Props> {
                     'italic',
                     'bulletedlist',
                     'numberedlist',
+                    'internalLink',
+                    'externalLink',
                 ],
                 heading: {
                     options: [
@@ -110,6 +114,8 @@ export default class CKEditor5Configurable extends React.Component<Props> {
                     'bulletedlist',
                     'numberedlist',
                     'fontcolor',
+                    'internalLink',
+                    'externalLink',
                 ],
                 heading: {
                     options: [
@@ -166,6 +172,8 @@ export default class CKEditor5Configurable extends React.Component<Props> {
                 'numberedlist',
                 'alignment',
                 'fontcolor',
+                'internalLink',
+                'externalLink',
                 'insertTable',
                 'code',
             ],
@@ -288,6 +296,8 @@ export default class CKEditor5Configurable extends React.Component<Props> {
                     TablePlugin,
                     TableToolbarPlugin,
                     FontPlugin,
+                    ExternalLinkPlugin,
+                    InternalLinkPlugin,
                     ...pluginRegistry.plugins,
                 ],
                 ...configRegistry.configs.reduce((previousConfig, config) => {


### PR DESCRIPTION
### **Feat: Enable Internal and External Link Plugins in CKEditor**

| Key               | Value |
|-------------------|-------|
| **Feature type**  | Enhancement |
| **New feature?**  |  Yes |
| **Bug fix?**      | No |
| **BC breaks?**    | No |
| **Deprecations?** | No |
| **Related issues/PRs** | – |
| **License**       | MIT   |

---

### **What’s in this update?**

-  **Enabled `internalLink` and `externalLink` plugins** in all CKEditor configurations (`default`, `inline`, `minimal`, etc.).
-  **Registered `ExternalLinkPlugin` and `InternalLinkPlugin`** from `sulu-admin-bundle` in the custom `CKEditor5Configurable.js` component.
-  Integrated both plugins into the toolbar setup for enhanced link management within content.

---

### **Why this is useful?**

Gives content editors the ability to add both internal and external links directly from the editor.  
Streamlines linking process by integrating native Sulu link plugins.  
Prepares the editor for more advanced use cases (e.g. linking to pages, media, documents, etc.).
